### PR TITLE
build:fix redux-thunk 版本，修复type报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-router-dom": "^4.2.2",
     "redux-actions": "^2.2.1",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.2.0",
+    "redux-thunk": "2.2.0",
     "uuid": "^3.1.0",
     "redux": "^3.6.0"
   },


### PR DESCRIPTION
`redux-thunk@2.3.0` 必须配合`redux@>4.0.0`的版本使用，否则会报types错误。
为了修复报错，考虑到dll中redux的版本，暂且将`redux-thunk`固定版本为2.2.0。
[Error参考链接](https://github.com/reduxjs/redux-thunk/issues/205)